### PR TITLE
Code Update and Typo

### DIFF
--- a/chapters/rigidBody.tex
+++ b/chapters/rigidBody.tex
@@ -119,7 +119,7 @@ a_3'
 \end{equation}
 We take the intermediate matrix out and define it as a matrix $ \mathbf{R}$. This matrix consists of the inner product between the two sets of bases, describing the same vector's coordinate transformation relationship before and after the rotation. As long as the rotation is the same, this matrix is the same. It can be said that the matrix $ \mathbf{R} $ describes the rotation itself. So we call it the \textit{rotation matrix}. Meanwhile, the components of the matrix are the inner product of the two coordinate system bases. Since the base vector's length is 1, it is actually the cosine of the angle between the base vectors. So this matrix is also called \textit{direction cosine matrix}. We will just call it the rotation matrix in the following.
 
-The rotation matrix has some special properties. In fact, it is an \textit{orthogonal} matrix with a determinant of 1 \footnote{Orthogonal matrix is a matrix whose inverse is its transpose. The orthogonality of the rotation matrix can be derived directly from the definition. } \footnote{The determinant is 1 is artificially defined. In fact, its determinant is $\pm 1 $, but the rotation with determinant $ - 1 $ is called \textit{improper rotation}, that is, one rotation plus one reflection in 3D space. }. Conversely, an orthogonal matrix with a determinant of 1 is also a rotation matrix. So, you can define a set of $n$ dimensional rotation matrices as follows:
+The rotation matrix has some special properties. In fact, it is an \textit{orthogonal} matrix with a determinant of 1 \footnote{Orthogonal matrix is a matrix whose inverse is its transpose. The orthogonality of the rotation matrix can be derived directly from the definition. } \footnote{The determinant of 1 is artificially defined. In fact, its determinant is $\pm 1 $, but the rotation with determinant $ - 1 $ is called \textit{improper rotation}, that is, one rotation plus one reflection in 3D space. }. Conversely, an orthogonal matrix with a determinant of 1 is also a rotation matrix. So, you can define a set of $n$ dimensional rotation matrices as follows:
 \begin{equation}
 \mathrm{SO}(n) = \{ \mathbf{R} \in \mathbb{R}^{n \times n} | \mathbf{R R}^T = \mathbf{I}, \mathrm{det} (\mathbf{R})=1 \}.
 \end{equation}
@@ -250,7 +250,7 @@ int main(int argc, char **argv) {
     // Eigen::Matrix<double, 3, 1>, which is a three-dimensional vector.
     Vector3d v_3d;
     // This is the same
-    Matrix<float, 3, 1> vd_3d;
+    Matrix<double, 3, 1> vd_3d;
     
     // Matrix3d is essentially Eigen::Matrix<double, 3, 3>
     Matrix3d matrix_33 = Matrix3d::Zero(); // initialized to zero
@@ -285,7 +285,7 @@ int main(int argc, char **argv) {
     Matrix<double, 2, 1> result = matrix_23.cast<double>() * v_3d;
     cout << "[1,2,3;4,5,6]*[3,2,1]=" << result.transpose() << endl;
     
-    Matrix<float, 2, 1> result2 = matrix_23 * vd_3d;
+    Matrix<float, 2, 1> result2 = matrix_23 * vd_3d.cast<float>();
     cout << "[1,2,3;4,5,6]*[4,5,6]: " << result2.transpose() << endl;
     
     // Also you can't misjudge the dimensions of the matrix

--- a/chapters/whatSlam.tex
+++ b/chapters/whatSlam.tex
@@ -235,7 +235,7 @@ Readers may say that the function $f,h$ here does not seem to specify what is go
     \Delta \theta
     \end{array} \right]_k} + {\mathbf{w}_k},
 \end{equation}
-where $\mathbf{w}_k$ is the noise again. This is a simple linear relationship. However, not all input commands are position and angular changes. For example, the input of ``throttle'' or ``joystick'' is the speed or acceleration, so there are other forms of more complex motion equations. At that time, we would say the kinetic analysis is required.
+where $\mathbf{w}_k$ is the noise again. This is a simple linear relationship. However, not all input commands are position and angular changes. For example, the input of ``throttle'' or ``joystick'' is the speed or acceleration, so there are other forms of more complex motion equations. At that time, we would say the kinematic analysis is required.
 
 Regarding the observation equation, for example, the robot carries a two-dimensional laser sensor. We know that a laser observes a 2D landmark by measuring two quantities: the distance $r$ between the landmark point and the robot, and the angle $\phi$. Let's say the landmark is at $\mathbf{y}_j = [y_1, y_2]_j^\mathrm{T}$, the pose is $\mathbf{x}_k=[x_1,x_2]_k^\mathrm{T}$, and the observed data is $\mathbf{z}_{k,j} = [r_{k,j}, \phi_{k,j}]^\mathrm{T}$, then the observation equation is written as:
 \begin{equation}


### PR DESCRIPTION
Hi @gaoxiang12 ,

First of all, thank you for your SLAM book repository, it's very useful to review the different parts of SLAM components with this book.

While reviewing the lectures, I found some typo with some of the chapters. Here are some of it:

- In chapter 1, when talking about position in SLAM, the correct term for motion analysis is kinematics. Kinetics is the study of force on an object, whereas kinematic is the study of how motion works.
- In chapter 2, in section 2.1.2, when specifying the determinant, there is repeated word of is, I've replaced it with "of" to avoid repetition.
- In chapter 2, in section 2.2, there is a code error in explaining the basics of Eigen. In line 26, `Vector3d v_3d` and in line 28 `Matrix<float, 3, 1> vd_3d`, the comment specifies it is the same, in which it is not. I've fixed line 28 to `Matrix<double, 3, 1> vd_3d`. The comment specifying it is the same would then make sense. In doing so, to do the matrix multiplication of the Eigen in line 64 of the code, I then cast the variable `vd_3d` to a float to be able to do the calculation.

Do let me know your thoughts in this, and please give me any feedback on the changes.